### PR TITLE
Show terminal error message

### DIFF
--- a/src/comm.c
+++ b/src/comm.c
@@ -175,7 +175,7 @@ meterd_rv meterd_comm_init(void)
 
 	if (comm_fd < 0)
 	{
-		ERROR_MSG("Failed to open serial terminal %s", tty);
+		ERROR_MSG("Failed to open serial terminal %s: %s", tty, strerror(errno));
 
 		free(tty);
 


### PR DESCRIPTION
I found myself in the situation where _meterd_ could not open the serial terminal. Without any suitable error message, debugging becomes much harder...
