### PR TITLE
use calloc instead of malloc + memset

### DIFF
--- a/src/meterd_config.c
+++ b/src/meterd_config.c
@@ -434,9 +434,7 @@ meterd_rv meterd_conf_get_scheduled_tasks(scheduled_task** tasks)
 				continue;
 			}
 
-			new_task = (scheduled_task*) malloc(sizeof(scheduled_task));
-
-			memset(new_task, 0, sizeof(scheduled_task));
+			new_task = (scheduled_task*) calloc(1, sizeof(scheduled_task));
 
 			for (j = 0; j < task_elem_count; j++)
 			{

--- a/src/meterd_output.c
+++ b/src/meterd_output.c
@@ -155,13 +155,9 @@ void meterd_output(sel_counter* sel_counters, const char* dbname, const char* ou
 	/* Allocate space for results from the database */
 	LL_COUNT(sel_counters, ctr_it, ctr_count);
 
-	results 	= (db_res_ctr**) malloc(ctr_count * sizeof(db_res_ctr*));
-	result_it	= (db_res_ctr**) malloc(ctr_count * sizeof(db_res_ctr*));
-	result_tmp	= (db_res_ctr**) malloc(ctr_count * sizeof(db_res_ctr*));
-
-	memset(results, 0, ctr_count * sizeof(db_res_ctr*));
-	memset(result_it, 0, ctr_count * sizeof(db_res_ctr*));
-	memset(result_tmp, 0, ctr_count * sizeof(db_res_ctr*));
+	results 	= (db_res_ctr**) calloc(ctr_count, sizeof(db_res_ctr*));
+	result_it	= (db_res_ctr**) calloc(ctr_count, sizeof(db_res_ctr*));
+	result_tmp	= (db_res_ctr**) calloc(ctr_count, sizeof(db_res_ctr*));
 
 	/* Retrieve results from the database */
 	i = 0;


### PR DESCRIPTION
This commit brings no functional changes to the code, but merely some (a) minor performance improvements, as well as (b) shorter code.